### PR TITLE
useDiceSet reconnect issue fix

### DIFF
--- a/packages/go-dice-api/src/dice-set.d.ts
+++ b/packages/go-dice-api/src/dice-set.d.ts
@@ -1,10 +1,11 @@
-import EventEmitter from './event-emitter';
-import Die from './die';
+import EventEmitter from "./event-emitter";
+import Die from "./die";
 
 declare const GoDice: any;
 
 export default class DiceSet extends EventEmitter {
-  requestDie (): void
+  requestDie(): void;
 
-  on (event: 'connected', handler: (die: Die) => void)
+  on(event: "connected", handler: (die: Die) => void);
+  on(event: "reconnected", handler: (die: Die) => void);
 }

--- a/packages/go-dice-api/src/dice-set.d.ts
+++ b/packages/go-dice-api/src/dice-set.d.ts
@@ -1,5 +1,5 @@
-import EventEmitter from "./event-emitter";
-import Die from "./die";
+import EventEmitter from './event-emitter';
+import Die from './die';
 
 declare const GoDice: any;
 

--- a/packages/go-dice-api/src/dice-set.d.ts
+++ b/packages/go-dice-api/src/dice-set.d.ts
@@ -6,6 +6,6 @@ declare const GoDice: any;
 export default class DiceSet extends EventEmitter {
   requestDie (): void
 
-  on (event: "connected", handler: (die: Die) => void)
-  on (event: "reconnected", handler: (die: Die) => void)
+  on (event: 'connected', handler: (die: Die) => void)
+  on (event: 'reconnected', handler: (die: Die) => void)
 }

--- a/packages/go-dice-api/src/dice-set.d.ts
+++ b/packages/go-dice-api/src/dice-set.d.ts
@@ -4,8 +4,8 @@ import Die from "./die";
 declare const GoDice: any;
 
 export default class DiceSet extends EventEmitter {
-  requestDie(): void;
+  requestDie (): void
 
-  on(event: "connected", handler: (die: Die) => void);
-  on(event: "reconnected", handler: (die: Die) => void);
+  on (event: "connected", handler: (die: Die) => void)
+  on (event: "reconnected", handler: (die: Die) => void)
 }

--- a/packages/go-dice-react/index.js
+++ b/packages/go-dice-react/index.js
@@ -11,6 +11,7 @@ export function useDiceSet() {
     };
 
     diceSet.on("connected", onDieConnected);
+    diceSet.on("reconnected", onDieConnected);
 
     return () => diceSet.off("connected", onDieConnected);
   }, []);


### PR DESCRIPTION
Added `diceSet.on("reconnected", onDieConnected)` to react hooks. This should fix issue of disconnected dice not being re-added to dice array when reconnected.